### PR TITLE
[ENG-537] Fix heatmap clustering matrix ordering

### DIFF
--- a/src/lpm_plot/plot_heatmap.py
+++ b/src/lpm_plot/plot_heatmap.py
@@ -72,10 +72,7 @@ def plot_heatmap(
         values="Score", index="Column 1", on="Column 2", aggregate_function="first"
     )
 
-    # Get the row labels (Column 1 values) - ensure all unique values are present
-    row_labels = df_pivot["Column 1"].to_list()
-    # Ensure all rows are present (add missing rows with nulls)
-    missing_rows = set(all_unique_values) - set(row_labels)
+    missing_rows = set(all_unique_values) - set(df_pivot["Column 1"].to_list())
     if missing_rows:
         missing_df = pl.DataFrame(
             {
@@ -88,38 +85,21 @@ def plot_heatmap(
             }
         )
         df_pivot = pl.concat([df_pivot, missing_df])
-        # Re-sort to match all_unique_values order
-        df_pivot = df_pivot.sort("Column 1")
-        row_labels = df_pivot["Column 1"].to_list()
 
-    # Get data columns (Column 2 values) - ensure all unique values are present as columns
-    data_columns = [col for col in df_pivot.columns if col != "Column 1"]
-    missing_cols = set(all_unique_values) - set(data_columns)
-    if missing_cols:
-        for col in missing_cols:
-            df_pivot = df_pivot.with_columns(pl.lit(None).alias(col))
+    for col in set(all_unique_values) - set(df_pivot.columns):
+        df_pivot = df_pivot.with_columns(pl.lit(None).alias(col))
 
-    # Ensure rows and columns are in the same order so the diagonal is correct
-    df_pivot = df_pivot.sort("Column 1")
-    row_labels = df_pivot["Column 1"].to_list()
-    df_pivot = df_pivot.select(["Column 1"] + row_labels)
-    data_columns = row_labels
+    df_pivot = df_pivot.sort("Column 1").select(["Column 1"] + all_unique_values)
+    data_matrix = df_pivot.select(all_unique_values).fill_null(0).to_numpy()
 
-    # Extract the data matrix (excluding the "Column 1" column) and convert to numpy
-    data_matrix = df_pivot.select(data_columns).fill_null(0).to_numpy()
-    np.fill_diagonal(data_matrix, 1.0)
-
-    # Create a condensed distance matrix from the pivoted matrix
     distance_matrix = 1 - data_matrix
-    condensed_matrix = distance_matrix  # Already a numpy array
+    np.fill_diagonal(distance_matrix, 0)
 
-    # Perform hierarchical clustering
     linkage_matrix = linkage(
-        squareform(condensed_matrix, checks=False), method="average"
+        squareform(distance_matrix, checks=False), method="average"
     )
 
-    # Get the order of the rows/columns after clustering
-    order = [row_labels[i] for i in leaves_list(linkage_matrix)]
+    order = [all_unique_values[i] for i in leaves_list(linkage_matrix)]
 
     # Define filter fields for selected cells (only if interactive)
     if interactive:

--- a/tests/test_plot_heatmap.py
+++ b/tests/test_plot_heatmap.py
@@ -24,6 +24,13 @@ def test_plot_heatmap_smoke():
     )
 
 
+def test_cluster_order():
+    df = pl.read_csv("tests/resources/heatmap-test-data.csv")
+    chart = plot_heatmap(df, interactive=False)
+    sort_order = chart.encoding.x.to_dict()["sort"]
+    assert sort_order == ["num1", "num2", "cat1", "cat2"]
+
+
 # %%
 if __name__ == "__main__":
     import polars as pl


### PR DESCRIPTION
## Summary

Simplify and harden the clustering pivot logic introduced in #13. The conditional missing-row sort, separate `data_columns` / `row_labels` tracking, and `condensed_matrix` alias are replaced with a single unconditional pipeline: sort rows, select columns by `all_unique_values`, zero the distance diagonal directly. Adds a regression test for UPGMA leaf order.

## BEFORE

```python
row_labels = df_pivot["Column 1"].to_list()
missing_rows = set(all_unique_values) - set(row_labels)
if missing_rows:
    ...
    df_pivot = df_pivot.sort("Column 1")
    row_labels = df_pivot["Column 1"].to_list()

missing_cols = set(all_unique_values) - set(data_columns)
if missing_cols:
    for col in missing_cols:
        df_pivot = df_pivot.with_columns(pl.lit(None).alias(col))

df_pivot = df_pivot.sort("Column 1")
row_labels = df_pivot["Column 1"].to_list()
df_pivot = df_pivot.select(["Column 1"] + row_labels)
data_matrix = df_pivot.select(data_columns).fill_null(0).to_numpy()
np.fill_diagonal(data_matrix, 1.0)

distance_matrix = 1 - data_matrix
condensed_matrix = distance_matrix
```

Multiple intermediate variables (`row_labels`, `data_columns`, `condensed_matrix`), two conditional sort paths, diagonal set to 1.0 on the data matrix (relying on `1 − 1 = 0` after subtraction).

## AFTER

```python
missing_rows = set(all_unique_values) - set(df_pivot["Column 1"].to_list())
if missing_rows:
    ...
    df_pivot = pl.concat([df_pivot, missing_df])

for col in set(all_unique_values) - set(df_pivot.columns):
    df_pivot = df_pivot.with_columns(pl.lit(None).alias(col))

df_pivot = df_pivot.sort("Column 1").select(["Column 1"] + all_unique_values)
data_matrix = df_pivot.select(all_unique_values).fill_null(0).to_numpy()

distance_matrix = 1 - data_matrix
np.fill_diagonal(distance_matrix, 0)
```

One unconditional sort+select, `all_unique_values` as the single canonical label source, diagonal zeroed directly on the distance matrix. Net −13 lines.

## Reviewer Validation

- [ ] `uv run pytest` passes all tests including the new `test_cluster_order`
- [ ] `test_cluster_order` asserts leaf order `["num1", "num2", "cat1", "cat2"]` on the 4×4 test matrix
- [ ] Verify no intermediate `row_labels` / `data_columns` / `condensed_matrix` variables remain